### PR TITLE
CHORE: Update dmn-check from 1.1.4 to 1.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<swagger.version>2.5.0</swagger.version>
 		<h2.version>1.4.193</h2.version>
 		<feel.scala.version>1.10.1</feel.scala.version>
-		<redsix.dmn-check.version>1.2.1</redsix.dmn-check.version>
+		<redsix.dmn-check.version>1.2.2</redsix.dmn-check.version>
 	</properties>
 
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<swagger.version>2.5.0</swagger.version>
 		<h2.version>1.4.193</h2.version>
 		<feel.scala.version>1.10.1</feel.scala.version>
-		<redsix.dmn-check.version>1.2.2</redsix.dmn-check.version>
+		<redsix.dmn-check.version>1.2.3</redsix.dmn-check.version>
 	</properties>
 
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 		<swagger.version>2.5.0</swagger.version>
 		<h2.version>1.4.193</h2.version>
 		<feel.scala.version>1.10.1</feel.scala.version>
-		<redsix.dmn-check.version>1.1.4</redsix.dmn-check.version>
+		<redsix.dmn-check.version>1.2.1</redsix.dmn-check.version>
 	</properties>
 
 	<scm>


### PR DESCRIPTION
## 1.2.3 (2022-04-18)

Bugfixes:

 - Only attempt to verify FEEL expressions and warn that other expression languages are currently unsupported (#83, #88, #98), thank you @nairagit.

## 1.2.2 (2022-03-30)

Bugfixes:

Allow negative numbers in the typechecker (#87), thank you @kishorehs123.

## 1.2.0 (2021-09-03)

Features:

  - Validation Server
    With this release dmn-check includes a validation server module. This server is supposed to run standalone and
    accepts validation requests via HTTP. It is currently used for an experimental integration into the Camunda
    Modeler. A demo version is live at https://dmn-check.pascal-wittmann.de/demo/.
  - A Gradle plugin that allows you to use dmn-check in your Gradle projects.
  - A maven module plugin-base that provides common functionality for build system plugins.
  - Adds failOnWarning flag to support failing validation on Warning severity (#18), thank you Krzysztof Barczynski.

Bugfixes:

  - Warn about conflicting rules for hit-policy collect and rule-order instead of reporting an error
  - Warn about duplicate rules for hit-policy collect instead of reporting an error

## 1.1.6 (2021-03-06)

Features:

  - Support DMN-1.3

Bugfixes:

  - Support for ItemComponents in ItemDefintionAllowedValuesTypeValidator
    An ItemDefintion can consist of multiple ItemComponent with their own
    AllowedValues. Now the AllowedValues in ItemComponents are typechecked 
    as well.

## 1.1.5 (2020-11-27)

Bugfixes:

  - Fix subsumption for string literals (issue #9)
  - Enforce that negations are not nested in FEEL expressions
  - Refine subsumption for variables